### PR TITLE
Add quic support

### DIFF
--- a/lib/connect/index.js
+++ b/lib/connect/index.js
@@ -15,6 +15,7 @@ if ((typeof process !== 'undefined' && process.title !== 'browser') || typeof __
   protocols.ssl = require('./tls')
   protocols.tls = require('./tls')
   protocols.mqtts = require('./tls')
+  protocols.quic = require('./quic')
 } else {
   protocols.wx = require('./wx')
   protocols.wxs = require('./wx')
@@ -84,7 +85,7 @@ function connect (brokerUrl, opts) {
 
   if (opts.cert && opts.key) {
     if (opts.protocol) {
-      if (['mqtts', 'wss', 'wxs', 'alis'].indexOf(opts.protocol) === -1) {
+      if (['mqtts', 'wss', 'wxs', 'alis', "quic"].indexOf(opts.protocol) === -1) {
         switch (opts.protocol) {
           case 'mqtt':
             opts.protocol = 'mqtts'

--- a/lib/connect/quic.js
+++ b/lib/connect/quic.js
@@ -1,0 +1,55 @@
+'use strict'
+var {createQuicSocket} = require('net')
+var debug = require('debug')('mqttjs:quic')
+
+function buildBuilder(mqttClient, opts) {
+  
+    opts.port = opts.port || 8885
+    opts.host = opts.hostname || opts.host || 'localhost'
+    opts.servername = opts.host
+
+    opts.rejectUnauthorized = opts.rejectUnauthorized !== false
+
+    delete opts.path
+
+    debug('port %d host %s rejectUnauthorized %b', opts.port, opts.host, opts.rejectUnauthorized)
+
+    const socket = createQuicSocket({
+        client: {
+            alpn: opts.alpn || 'mqtt',
+        }
+    })
+
+    const req = socket.connect({
+        address: opts.host,
+        port: opts.port || 8885,
+        cert: opts.cert,
+        key: opts.key
+    })
+
+    var stream = req.openStream()
+    
+    req.on('secure', function (servername) {
+        // servername is checked for any string for authorisation acceptance
+        if (opts.rejectUnauthorized && !servername) {
+            req.emit('error', new Error('TLS not authorized'))
+        } else {
+            req.removeListener('error', handleTLSErrors)
+        }
+    })
+
+    function handleTLSErrors(err) {
+        
+        if (opts.rejectUnauthorized) {
+            mqttClient.emit('error', err)
+        }
+
+        stream.end()
+        socket.close()
+    }
+
+    req.on('error', handleTLSErrors)
+    return stream
+}
+
+module.exports = buildBuilder


### PR DESCRIPTION
Added support for QUIC protocol through the core QUIC module of NodeJS (v15 - pre)

[NodeJS QUIC Documentation](https://nodejs.org/dist/v15.7.0/docs/api/quic.html)